### PR TITLE
Fix bug in opb base features

### DIFF
--- a/src/extract/OPBBaseFeatures.cc
+++ b/src/extract/OPBBaseFeatures.cc
@@ -61,6 +61,7 @@ OPB::Constr::Constr(StreamBuffer &in) : terms(in) {
         in.skipString(">=");
     } else {
         assert(*in == '=');
+        rel = EQ;
         in.skip();
     }
     in.readNumber(&strbound);


### PR DESCRIPTION
The `rel` field of `OPB::Constr` is uninitialized by default, leading to equality constraints being not properly detected.