### PR TITLE
Simple fix for mixup of horn and inv_horn counting when extracting the features

### DIFF
--- a/src/extract/CNFBaseFeatures.cc
+++ b/src/extract/CNFBaseFeatures.cc
@@ -51,15 +51,15 @@ void CNF::BaseFeatures1::run() {
         }
         // horn statistics
         unsigned n_pos = clause.size() - n_neg;
-        if (n_neg <= 1) {
-            if (n_neg == 0) ++positive;
+        if (n_pos <= 1) {
+            if (n_pos == 0) ++negative;
             ++horn;
             for (Lit lit : clause) {
                 ++variable_horn[lit.var()];
             }
         }
-        if (n_pos <= 1) {
-            if (n_pos == 0) ++negative;
+        if (n_neg <= 1) {
+            if (n_neg == 0) ++positive;
             ++inv_horn;
             for (Lit lit : clause) {
                 ++variable_inv_horn[lit.var()];

--- a/src/extract/WCNFBaseFeatures.cc
+++ b/src/extract/WCNFBaseFeatures.cc
@@ -91,15 +91,15 @@ void WCNF::BaseFeatures1::run() {
 
             // horn statistics
             unsigned n_pos = clause.size() - n_neg;
-            if (n_neg <= 1) {
-                if (n_neg == 0) ++positive;
+            if (n_pos <= 1) {
+                if (n_pos == 0) ++negative;
                 ++horn;
                 for (Lit lit : clause) {
                     ++variable_horn[lit.var()];
                 }
             }
-            if (n_pos <= 1) {
-                if (n_pos == 0) ++negative;
+            if (n_neg <= 1) {
+                if (n_neg == 0) ++positive;
                 ++inv_horn;
                 for (Lit lit : clause) {
                     ++variable_inv_horn[lit.var()];

--- a/src/util/CNFFormula.h
+++ b/src/util/CNFFormula.h
@@ -30,11 +30,12 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 class CNFFormula {
     For formula;
-    unsigned variables;
-    unsigned total_literals;
+    unsigned variables = 0;
+    unsigned total_literals = 0;
+    unsigned max_clause_len = 0;
 
  public:
-    CNFFormula() : formula(), variables(0) { }
+    CNFFormula() = default;
 
     explicit CNFFormula(const char* filename) : CNFFormula() {
         readDimacsFromFile(filename);
@@ -74,6 +75,14 @@ class CNFFormula {
 
     inline int newVar() {
         return ++variables;
+    }
+
+    inline size_t maxClauseLength() const { 
+        return max_clause_len; 
+    }
+
+    inline const For& clauses() const { 
+        return formula; 
     }
 
     inline void clear() {
@@ -142,6 +151,7 @@ class CNFFormula {
                 }
             }
             clause->resize(clause->size() - dup);
+            max_clause_len = std::max(max_clause_len, static_cast<unsigned>(clause->size()));
             clause->shrink_to_fit();
             variables = std::max(variables, (unsigned int)clause->back().var());
             total_literals += clause->size();
@@ -151,4 +161,3 @@ class CNFFormula {
 };
 
 #endif  // SRC_UTIL_CNFFORMULA_H_
-


### PR DESCRIPTION
since horn clauses contain at most one positive literal and inv_horn at most one negative literal, it should be the other way around when counting when extracting base features