### PR TITLE
Fixed Mapping Behaviour in CNFFormula and small fixes to constructor and clear method.

### DIFF
--- a/src/util/CNFFormula.h
+++ b/src/util/CNFFormula.h
@@ -34,7 +34,7 @@ class CNFFormula {
     unsigned total_literals;
 
  public:
-    CNFFormula() : formula(), variables(0) { }
+    CNFFormula() : formula(), variables(0), total_literals(0) { }
 
     explicit CNFFormula(const char* filename) : CNFFormula() {
         readDimacsFromFile(filename);
@@ -77,21 +77,22 @@ class CNFFormula {
     }
 
     inline void clear() {
+        for (Cl* clause : formula) delete clause;
         formula.clear();
+        variables = 0;
+        total_literals = 0;
     }
 
-    // create gapless representation of variables
     void normalizeVariableNames() {
-        std::vector<unsigned> name;
-        name.resize(variables+1, 0);
-        unsigned int max = 0;
+        std::vector<unsigned> map(variables + 1, 0);
+        unsigned next = 1;
         for (Cl* clause : formula) {
             for (Lit& lit : *clause) {
-                if (name[lit.var()] == 0) name[lit.var()] = max++;
-                lit = Lit(name[lit.var()], lit.sign());
+                if (map[lit.var()] == 0) map[lit.var()] = next++;
+                lit = Lit(map[lit.var()], lit.sign());
             }
         }
-        variables = max;
+        variables = next - 1;
     }
 
     void readDimacsFromFile(const char* filename) {


### PR DESCRIPTION
Fixed in **CNFFormula**
- Mapping Behaviour of normalizeVariableNames Function

Previously it used 0 as a way of saying that it's unmapped, but then also assigned 0 as first new variable ID. This lead to pretty bad inconsistencies, which I recognized when I scrambled clauses and variables and analyzed their structure. 

It can still be improved further by making it even clause-order invariant with:
```cpp
    inline void normalizeVariableNames() {
        if (variables == 0 || formula.empty()) return;

        std::vector<char> seen(variables + 1, 0);
        for (const Cl* clause : formula)
            for (const Lit& lit : *clause)
                seen[(unsigned)lit.var()] = 1;

        std::vector<unsigned> map(variables + 1, 0);
        unsigned next = 1;
        for (unsigned v = 1; v <= variables; ++v)
            if (seen[v]) map[v] = next++;

        for (Cl* clause : formula)
            for (Lit& lit : *clause)
                lit = Lit(map[(unsigned)lit.var()], lit.sign());

        variables = next - 1;
    }
```
for example

also added
- initialization of total_literals in constructor
- proper resetting of variables and freeing of memory in clear method